### PR TITLE
Allow running tests directly on runner

### DIFF
--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -3,13 +3,26 @@ name: Test Action
 on: [push, pull_request]
 
 jobs:
-  TestAction:
+  test_1:
+    name: "Test Action with Container"
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Run Action
-      id: run_tests
       uses: ./
       with:
         directory: test_proj
+  test_2:
+    name: "Test Action Locally"
+    runs-on: ubuntu-latest
+    container:
+      image: barichello/godot-ci:latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Run Action
+      uses: ./
+      with:
+        directory: test_proj
+        useContainer: false

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -30,6 +30,11 @@ steps:
 
     Boolean value of whether or not to run container. Defaults to `true`
 
+#### godotExecutable
+
+    Path of Godot binary to call when running GUT tests. Defaults to `godot`
+
+
 ## Configure GUT
 
 This action requires you to configure GUT using the `.gutconfig.json` file which would be located in the root directory of your project.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -26,6 +26,10 @@ steps:
 
     The name directory to run tests within. Defaults to the current directory.
 
+#### useContainer
+
+    Boolean value of whether or not to run container. Defaults to `true`
+
 ## Configure GUT
 
 This action requires you to configure GUT using the `.gutconfig.json` file which would be located in the root directory of your project.

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
   containerImage:
     description: "The container to run tests inside of."
     default: "barichello/godot-ci:latest"
+  useContainer:
+    description: "Boolean value of whether or not to run container."
+    default: true
   directory:
     description: "The name directory to run tests in."
 runs:

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   useContainer:
     description: "Boolean value of whether or not to run container."
     default: true
+  godotExecutable:
+    description: "Path of Godot binary to call when running GUT tests."
+    default: godot
   directory:
     description: "The name directory to run tests in."
 runs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -12254,6 +12254,7 @@ try {
   var docker_image = core.getInput('containerImage');
   var work_dir = core.getInput('directory');
   var use_container = core.getInput('useContainer');
+  var godot_executable = core.getInput('godotExecutable');
 
   if(work_dir)
   {
@@ -12274,7 +12275,7 @@ try {
       function onFinished(err, output)
       {
         console.log("Starting image...")
-        docker.run(docker_image, ['godot', '-d', '-s', '--path', '/project', 'addons/gut/gut_cmdln.gd'], process.stdout, 
+        docker.run(docker_image, [godot_executable, '-d', '-s', '--path', '/project', 'addons/gut/gut_cmdln.gd'], process.stdout, 
         
         // Mount working directory to `/project`
         { HostConfig: { Binds: [ process.cwd() + ":/project" ] }},
@@ -12303,7 +12304,7 @@ try {
   {
     console.log("Running GUT tests locally");
 
-    var result = spawnSync('godot -d -s --path . addons/gut/gut_cmdln.gd', {
+    var result = spawnSync(`${godot_executable} -d -s --path . addons/gut/gut_cmdln.gd`, {
       stdio: 'inherit',
       shell: true
     });

--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
 const core = require('@actions/core');
+const { spawnSync } = require("child_process");
 const fs = require('fs');
 const path = require('path')
 
@@ -11,47 +12,67 @@ try {
   // Get inputs
   var docker_image = core.getInput('containerImage');
   var work_dir = core.getInput('directory');
+  var use_container = core.getInput('useContainer');
 
   if(work_dir)
   {
     process.chdir(work_dir);
   }
 
-  // Pull docker image for building
-  console.log("Pulling build image...");
-  docker.pull(docker_image, function(err, stream)
-  {
+  if(use_container == "true")
+  {  
 
-    docker.modem.followProgress(stream, onFinished, onProgress);
-
-    // Wait to run build until after pull complete
-    function onFinished(err, output)
+    // Pull docker image for building
+    console.log("Pulling build image...");
+    docker.pull(docker_image, function(err, stream)
     {
-      console.log("Starting image...")
-      docker.run(docker_image, ['godot', '-d', '-s', '--path', '/project', 'addons/gut/gut_cmdln.gd'], process.stdout, 
+
+      docker.modem.followProgress(stream, onFinished, onProgress);
+
+      // Wait to run build until after pull complete
+      function onFinished(err, output)
+      {
+        console.log("Starting image...")
+        docker.run(docker_image, ['godot', '-d', '-s', '--path', '/project', 'addons/gut/gut_cmdln.gd'], process.stdout, 
+        
+        // Mount working directory to `/project`
+        { HostConfig: { Binds: [ process.cwd() + ":/project" ] }},
+        
+        function (err, data, container) {
+
+          if(err)
+          {
+            core.setFailed(error.message);
+          }
+
+          console.log("Tests exited with status: " + data.StatusCode);
+
+          if( data.StatusCode != "0" )
+          {
+              core.setFailed("GUT tests failed!");
+          }
       
-      // Mount working directory to `/project`
-      { HostConfig: { Binds: [ process.cwd() + ":/project" ] }},
-      
-      function (err, data, container) {
+        })
+      }
+      function onProgress(event) {}
 
-        if(err)
-        {
-          core.setFailed(error.message);
-        }
+    });
+  }
+  else
+  {
+    console.log("Running GUT tests locally");
 
-        console.log("Tests exited with status: " + data.StatusCode);
+    var result = spawnSync('godot -d -s --path . addons/gut/gut_cmdln.gd', {
+      stdio: 'inherit',
+      shell: true
+    });
 
-        if( data.StatusCode != "0" )
-        {
-            core.setFailed("GUT tests failed!");
-        }
-    
-      })
+    if(result.status != null && result.status != 0)
+    {
+      core.setFailed("GUT tests failed!");
     }
-    function onProgress(event) {}
-
-  });
+  
+  }
 
 } catch (error) {
   core.setFailed(error.message);

--- a/main.js
+++ b/main.js
@@ -13,6 +13,7 @@ try {
   var docker_image = core.getInput('containerImage');
   var work_dir = core.getInput('directory');
   var use_container = core.getInput('useContainer');
+  var godot_executable = core.getInput('godotExecutable');
 
   if(work_dir)
   {
@@ -33,7 +34,7 @@ try {
       function onFinished(err, output)
       {
         console.log("Starting image...")
-        docker.run(docker_image, ['godot', '-d', '-s', '--path', '/project', 'addons/gut/gut_cmdln.gd'], process.stdout, 
+        docker.run(docker_image, [godot_executable, '-d', '-s', '--path', '/project', 'addons/gut/gut_cmdln.gd'], process.stdout, 
         
         // Mount working directory to `/project`
         { HostConfig: { Binds: [ process.cwd() + ":/project" ] }},
@@ -62,7 +63,7 @@ try {
   {
     console.log("Running GUT tests locally");
 
-    var result = spawnSync('godot -d -s --path . addons/gut/gut_cmdln.gd', {
+    var result = spawnSync(`${godot_executable} -d -s --path . addons/gut/gut_cmdln.gd`, {
       stdio: 'inherit',
       shell: true
     });

--- a/package.json
+++ b/package.json
@@ -1,26 +1,26 @@
 {
-    "name": "run-gut-tests-action",
-    "version": "1.0.0",
-    "description": "",
-    "main": "dist/main.js",
-    "scripts": {
-      "test": "echo \"Error: no test specified\" && exit 1",
-      "package": "ncc build main.js -o dist"
-    },
-    "repository": {
-      "type": "git",
-      "url": "git+https://github.com/josephbmanley/run-gut-tests-action.git"
-    },
-    "keywords": [],
-    "author": "",
-    "license": "ISC",
-    "bugs": {
-      "url": "https://github.com/josephbmanley/run-gut-tests-action/issues"
-    },
-    "homepage": "https://github.com/josephbmanley/run-gut-tests-action#readme",
-    "dependencies": {
-      "@actions/core": "^1.2.6",
-      "@zeit/ncc": "^0.22.3",
-      "dockerode": "^3.2.1"
-    }
+  "name": "run-gut-tests-action",
+  "version": "1.0.0",
+  "description": "",
+  "main": "dist/main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "package": "ncc build main.js -o dist"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/josephbmanley/run-gut-tests-action.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/josephbmanley/run-gut-tests-action/issues"
+  },
+  "homepage": "https://github.com/josephbmanley/run-gut-tests-action#readme",
+  "dependencies": {
+    "@actions/core": "^1.2.6",
+    "@zeit/ncc": "^0.22.3",
+    "dockerode": "^3.2.1"
   }
+}


### PR DESCRIPTION
# Changes
- Adds `useContainer` that when set to `false` will just execute GUT tests on local runner
- Adds `godotExecutable` to change/configure executable for GUT to use